### PR TITLE
Feat/#slope 24  통행불편 관련 모달 조회 api 연동 완료

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
     "eslint-plugin-simple-import-sort": "^12.1.0",
     "prettier": "^3.3.1",
     "tailwindcss": "^3.4.3"
-  }
+  },
+  "proxy" : "http://localhost:8080/"
 }

--- a/src/components/CallTaxiModal/CallTaxiModal.tsx
+++ b/src/components/CallTaxiModal/CallTaxiModal.tsx
@@ -1,29 +1,62 @@
-const CallTaxiModal = () => {
-  const phoneNumber = "1588-4388";
+import { RoadReportCallTaxi } from "../../types/RoadReportCallTaxi";
 
+type Props = {
+  callTaxi: RoadReportCallTaxi;
+};
+const CallTaxiModal = ({ callTaxi }: Props) => {
+  const phoneNumber = callTaxi.callTaxiContact;
+  const canOnlineReserve = callTaxi.canOnlineReserve;
+  const homePage = callTaxi.homePage;
+
+  const getButtonText = () => {
+    if (canOnlineReserve && homePage) {
+      return "온라인 예약";
+    } else if (homePage) {
+      return "홈페이지";
+    }
+    return null;
+  };
+
+  const buttonText = getButtonText();
   return (
-    <div>
-      <div className="mb-5 pt-3">
-        <p className="text-center">현재 위치한 지역을 기반으로</p>
-        <p className="text-center">
-          <span
-            className="text-center font-bold text-lg"
-            style={{ color: "#3F51B5" }}
-          >
-            장애인 콜택시
-          </span>
-          를 호출합니다.
-        </p>
+    <div
+      className="h-[180px] w-[360px]"
+      // style={{ backgroundColor: "yellowgreen" }}
+    >
+      {/* <div className="relative">
+        <span className="absolute bottom-1 text-sm bottom-6">
+          장애인 콜택시 연결
+        </span>
+      </div> */}
+      <div className="mb-2 pt-5">
+        <p className="text-center">마커에 위치한 지역을 기반으로</p>
+        <p className="text-center">장애인 콜택시를 연결합니다.</p>
+        <div
+          className="flex items-center justify-center text-center font-bold text-lg h-[60px]"
+          style={{ color: "#3F51B5" }}
+        >
+          {callTaxi.callTaxiName}
+        </div>
       </div>
-      <div className="text-center">
+      <div className="flex justify-center gap-4">
         <a href={`tel:${phoneNumber}`}>
           <button
-            className="w-[82px] h-[30px] rounded-lg shadow-md"
+            className="w-[100px] h-[35px] rounded-lg"
             style={{ backgroundColor: "#F8837C", color: "white" }}
           >
-            전화연결
+            전화 예약
           </button>
         </a>
+        {buttonText && homePage && (
+          <a href={homePage} target="_blank" rel="noopener noreferrer">
+            <button
+              className="w-[100px] h-[35px] rounded-lg"
+              style={{ backgroundColor: "#4CAF50", color: "white" }}
+            >
+              {buttonText}
+            </button>
+          </a>
+        )}
       </div>
     </div>
   );

--- a/src/components/RoadCenterListModal/RoadCenterListModal.tsx
+++ b/src/components/RoadCenterListModal/RoadCenterListModal.tsx
@@ -1,68 +1,16 @@
-const RoadCenterListModal = () => {
-  // 임시 데이터
-  const centerData = [
-    {
-      id: 1,
-      name: "서울지방국토관리청",
-      tel: "02-2110-0691",
-    },
-    {
-      id: 2,
-      name: "수원국토관리사무소",
-      tel: "031-283-0648",
-    },
-    {
-      id: 3,
-      name: "의정부국토관리사무소",
-      tel: "031-847-7680",
-    },
-    {
-      id: 4,
-      name: "원주지방국토관리청",
-      tel: "033-746-6785",
-    },
-    {
-      id: 5,
-      name: "홍천국토관리사무소",
-      tel: "033-435-5982",
-    },
-    {
-      id: 6,
-      name: "강릉국토관리사무소",
-      tel: "033-650-8833",
-    },
-    {
-      id: 7,
-      name: "홍천국토관리사무소",
-      tel: "033-435-5982",
-    },
-    {
-      id: 8,
-      name: "정선국토관리사무소",
-      tel: "033-563-6767",
-    },
-    {
-      id: 9,
-      name: "강릉국토관리사무소",
-      tel: "033-563-0757",
-    },
-    {
-      id: 10,
-      name: "대전지방국토관리사무소",
-      tel: "042-670-3485",
-    },
-    {
-      id: 11,
-      name: "전주지방국토관리사무소",
-      tel: "042-670-3485",
-    },
-    {
-      id: 12,
-      name: "전주지방국토관리사무소",
-      tel: "042-670-3485",
-    },
-  ];
+import { RoadReportCenter } from "../../types/roadReportCenter";
 
+type Props = {
+  centerListState: boolean;
+  stateChangeFunc: () => void;
+  centerList: RoadReportCenter[];
+};
+
+const RoadCenterListModal = ({
+  centerList,
+  centerListState,
+  stateChangeFunc,
+}: Props) => {
   const handleClick = (url: string) => {
     window.open(url, "_blank");
   };
@@ -96,18 +44,22 @@ const RoadCenterListModal = () => {
         </button>
       </div>
       <div className="overflow-auto" style={{ maxHeight: "430px" }}>
-        {centerData.map((center) => (
-          <button
-            key={center.id}
-            className={`relative block w-full mb-3 h-[30px] flex items-center justify-center rounded-xl ${center.id % 2 === 0 ? "bg-blue-200" : "bg-green-200"}`}
-            style={{
-              backgroundColor: center.id % 2 === 0 ? "#EAEAEA" : "#C5CBE9",
-            }}
-          >
-            <p className="absolute left-2 mx-2 text-left">{center.name}</p>
-            <p className="absolute right-2 mx-2 text-right">{center.tel}</p>
-          </button>
-        ))}
+        {centerList &&
+          centerList.map((center) => (
+            <button
+              key={center.id}
+              className={`relative block w-full mb-4 h-[35px] flex items-center rounded-xl ${center.id % 2 === 0 ? "bg-blue-200" : "bg-green-200"} hover:text-black hover:font-bold transition-all duration-200`}
+              style={{
+                backgroundColor: center.id % 2 === 0 ? "#EAEAEA" : "#C5CBE9",
+              }}
+              onClick={() =>
+                (window.location.href = `tel:${center.centerContact}`)
+              }
+            >
+              <p className="absolute left-3">{center.centerName}</p>
+              <p className="absolute right-3">{center.centerContact}</p>
+            </button>
+          ))}
       </div>
     </div>
   );

--- a/src/components/RoadReportCallModal/RoadReportCallModal.tsx
+++ b/src/components/RoadReportCallModal/RoadReportCallModal.tsx
@@ -1,11 +1,15 @@
+import { RoadReportCenter } from "../../types/roadReportCenter";
+
 type Props = {
   complaintCallState: boolean;
   stateChangeFunc: (state: boolean) => void;
   centerListSetState: () => void;
+  complaintCenter: RoadReportCenter;
 };
 
 const RoadReportCallModal = ({
   complaintCallState,
+  complaintCenter,
   stateChangeFunc,
   centerListSetState,
 }: Props) => {
@@ -24,26 +28,29 @@ const RoadReportCallModal = ({
           className="text-center font-bold text-2xl m-4 mt-7"
           style={{ color: "#3F51B5" }}
         >
-          서울지방국토관리청
+          {complaintCenter && complaintCenter.centerName}
         </p>
       </div>
       <div className="mb-5">
-        <p className="text-center">현재 위치를 기반으로</p>
-        <p className="text-center">해당 지역의 기관에 연결합니다.</p>
+        <p className="text-center">마커 위치를 기반으로</p>
+        <p className="text-center">해당 지역의 민원기관을 연결합니다.</p>
       </div>
       <div className="text-center">
         <button
-          className="p-0 w-[82px] h-[30px] left-118 top-453 rounded-lg shadow-md mr-6"
+          className="p-0 w-[85px] h-[30px] left-118 top-453 rounded-lg mr-5"
           style={{ backgroundColor: "#F8837C", color: "white" }}
+          onClick={() =>
+            (window.location.href = `tel:${complaintCenter.centerContact}`)
+          }
         >
-          전화연결
+          전화 연결
         </button>
         <button
-          className="p-0 w-[82px] h-[30px] left-118 top-453 rounded-lg shadow-md"
+          className="p-0 w-[85px] h-[30px] left-118 top-453 rounded-lg"
           style={{ backgroundColor: "#3F51B5", color: "white" }}
           onClick={handleCenterList}
         >
-          기관목록
+          기관 목록
         </button>
       </div>
     </div>

--- a/src/components/RoadReportCallModal/RoadReportCallModal.tsx
+++ b/src/components/RoadReportCallModal/RoadReportCallModal.tsx
@@ -1,17 +1,17 @@
 type Props = {
-  isComplaintCallModalOpen: boolean;
-  stateChange: (state: boolean) => void;
-  openCenterListModal: () => void;
+  complaintCallState: boolean;
+  stateChangeFunc: (state: boolean) => void;
+  centerListSetState: () => void;
 };
 
 const RoadReportCallModal = ({
-  isComplaintCallModalOpen,
-  stateChange,
-  openCenterListModal,
+  complaintCallState,
+  stateChangeFunc,
+  centerListSetState,
 }: Props) => {
   const handleCenterList = () => {
-    stateChange(!isComplaintCallModalOpen);
-    openCenterListModal();
+    stateChangeFunc(!complaintCallState);
+    centerListSetState();
   };
 
   return (

--- a/src/components/RoadTroubleImageSlide/RoadTroubleImageSlide.module.css
+++ b/src/components/RoadTroubleImageSlide/RoadTroubleImageSlide.module.css
@@ -1,11 +1,10 @@
-.imageContentWrap {
+/* .imageContentWrap {
   display: flex;
   justify-content: center;
   flex-wrap: wrap;
 }
 
 .mainImage {
-  width: 800px;
   margin-top: 10px;
   margin-bottom: 5px;
   border-radius: 5%;
@@ -20,11 +19,16 @@
   margin-bottom: 10px;
 }
 
+.previewImagesWrap {
+  display: flex;
+  justify-content: center;
+}
+
 .previewImage {
   width: 80px;
   height: 80px;
   border-radius: 10%;
-  object-fit: cove1r;
+  object-fit: cover;
   margin-right: 10px;
   cursor: pointer;
 }
@@ -32,4 +36,57 @@
 .buttonIcon {
   cursor: pointer;
   margin-top: 35%;
+} */
+
+.imageContentWrap {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.mainImage {
+  width: 320px;
+  height: 250px;
+  margin-top: 10px;
+  margin-bottom: 5px;
+  border-radius: 5%;
+}
+
+.mainImageWrap {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+  margin-bottom: 10px;
+}
+
+.previewImagesWrap {
+  display: flex;
+  justify-content: center;
+}
+
+.previewImage {
+  width: 80px;
+  height: 80px;
+  border-radius: 10%;
+  object-fit: cover;
+  margin-right: 10px;
+  cursor: pointer;
+}
+
+.buttonIcon {
+  cursor: pointer;
+  position: absolute;
+  z-index: 1;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+.buttonIcon:first-of-type {
+  left: -10px;
+}
+
+.buttonIcon:last-of-type {
+  right: -10px;
 }

--- a/src/components/RoadTroubleImageSlide/RoadTroubleImageSlide.tsx
+++ b/src/components/RoadTroubleImageSlide/RoadTroubleImageSlide.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import styles from "./RoadTroubleImageSlide.module.css";
+import { RoadReportImage } from "../../types/roadReportImage";
 
 const images = [
   { source: process.env.PUBLIC_URL + "/img/road_trouble_bollard.png" },
@@ -7,9 +8,12 @@ const images = [
   { source: process.env.PUBLIC_URL + "/img/road_trouble_construct.png" },
 ];
 
-const RoadTroubleImageSlide = () => {
-  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+type Props = {
+  roadReportImage: RoadReportImage[];
+};
 
+const RoadTroubleImageSlide = ({ roadReportImage }: Props) => {
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
   const onClickImage = (index: number) => {
     setSelectedImageIndex(index);
   };
@@ -43,11 +47,13 @@ const RoadTroubleImageSlide = () => {
             strokeLinejoin="round"
           />
         </svg>
-        <img
-          src={images[selectedImageIndex].source}
-          alt="Road Trouble Image"
-          className={styles.mainImage}
-        />
+        {roadReportImage.length > 0 && (
+          <img
+            src={roadReportImage[selectedImageIndex].url}
+            alt="Road Trouble Image"
+            className={styles.mainImage}
+          />
+        )}
         <svg
           className={styles.buttonIcon}
           xmlns="http://www.w3.org/2000/svg"
@@ -66,15 +72,19 @@ const RoadTroubleImageSlide = () => {
           />
         </svg>
       </div>
-      {images.map((image, index) => (
-        <img
-          key={index}
-          src={image.source}
-          alt={`Image ${index}`}
-          className={styles.previewImage}
-          onClick={() => onClickImage(index)}
-        />
-      ))}
+      {roadReportImage.length > 1 && (
+        <div className={styles.previewImagesWrap}>
+          {roadReportImage.map((image, index) => (
+            <img
+              key={index}
+              src={image.url}
+              alt={`통행불편 제보 사진${index}`}
+              className={styles.previewImage}
+              onClick={() => onClickImage(index)}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/RoadTroubleModal/RoadTroubleModal.tsx
+++ b/src/components/RoadTroubleModal/RoadTroubleModal.tsx
@@ -1,13 +1,13 @@
-import { RiSpeakFill } from "react-icons/ri";
 import { FaTaxi } from "react-icons/fa";
+import { RiSpeakFill } from "react-icons/ri";
 import RoadTroubleImageSlide from "../RoadTroubleImageSlide/RoadTroubleImageSlide";
 
 type Props = {
-  stateChange: () => void;
-  callTaxiModalHandle: () => void;
+  callTaxiModalFunc: () => void;
+  stateChangeFunc: () => void;
 };
 
-const RoadTroubleModal = ({ stateChange, callTaxiModalHandle }: Props) => {
+const RoadTroubleModal = ({ callTaxiModalFunc, stateChangeFunc }: Props) => {
   return (
     <div className="max-w-[380px]">
       <div className="w-[380px] h-[360px]">
@@ -20,19 +20,23 @@ const RoadTroubleModal = ({ stateChange, callTaxiModalHandle }: Props) => {
       <div className="h-[50px] flex items-center">
         <p className="flex space-x-4">
           <button
-            onClick={stateChange}
+            onClick={stateChangeFunc}
             className="flex items-center justify-center flex-col mr-1"
           >
             <RiSpeakFill size={20} color="#404040" />
             <span>민원</span>
           </button>
-          <button className="flex items-center justify-center flex-col">
+          <button
+            onClick={callTaxiModalFunc}
+            className="flex items-center justify-center flex-col"
+          >
             <FaTaxi size={20} color="#404040" />
-            <span onClick={callTaxiModalHandle}>콜택시</span>
+            <span>콜택시</span>
           </button>
         </p>
       </div>
     </div>
   );
 };
+
 export default RoadTroubleModal;

--- a/src/components/RoadTroubleModal/RoadTroubleModal.tsx
+++ b/src/components/RoadTroubleModal/RoadTroubleModal.tsx
@@ -1,41 +1,50 @@
 import { FaTaxi } from "react-icons/fa";
 import { RiSpeakFill } from "react-icons/ri";
 import RoadTroubleImageSlide from "../RoadTroubleImageSlide/RoadTroubleImageSlide";
+import { RoadReportDetail } from "../../types/roadReportDetail";
 
 type Props = {
   callTaxiModalFunc: () => void;
   stateChangeFunc: () => void;
+  roadReport: RoadReportDetail;
 };
 
-const RoadTroubleModal = ({ callTaxiModalFunc, stateChangeFunc }: Props) => {
+const RoadTroubleModal = ({
+  roadReport,
+  callTaxiModalFunc,
+  stateChangeFunc,
+}: Props) => {
   return (
-    <div className="max-w-[380px]">
-      <div className="w-[380px] h-[360px]">
-        <RoadTroubleImageSlide></RoadTroubleImageSlide>
-      </div>
-      <div className="h-[130px] pt-5 mb-3">
-        횡단보도 앞쪽 볼라드 설치가 무너져있습니다. 또, 공사 현장 및 도로 파손이
-        있어 통행에 위험을 겪고 있습니다. 공사 기간은 2025.06월까지라고 합니다.
-      </div>
-      <div className="h-[50px] flex items-center">
-        <p className="flex space-x-4">
-          <button
-            onClick={stateChangeFunc}
-            className="flex items-center justify-center flex-col mr-1"
-          >
-            <RiSpeakFill size={20} color="#404040" />
-            <span>민원</span>
-          </button>
-          <button
-            onClick={callTaxiModalFunc}
-            className="flex items-center justify-center flex-col"
-          >
-            <FaTaxi size={20} color="#404040" />
-            <span>콜택시</span>
-          </button>
-        </p>
-      </div>
-    </div>
+    <>
+      {roadReport && (
+        <div className="max-w-[380px]">
+          <div className="w-[380px] h-[360px]">
+            <RoadTroubleImageSlide
+              roadReportImage={roadReport.reportImageList}
+            />
+          </div>
+          <div className="h-[130px] pt-5 mb-3">{roadReport.content}</div>
+          <div className="h-[50px] flex items-center">
+            <p className="flex space-x-4">
+              <button
+                onClick={stateChangeFunc}
+                className="flex items-center justify-center flex-col mr-1"
+              >
+                <RiSpeakFill size={20} color="#404040" />
+                <span>민원</span>
+              </button>
+              <button
+                onClick={callTaxiModalFunc}
+                className="flex items-center justify-center flex-col"
+              >
+                <FaTaxi size={20} color="#404040" />
+                <span>콜택시</span>
+              </button>
+            </p>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/pages/RoadReport/RoadReportForm.tsx
+++ b/src/pages/RoadReport/RoadReportForm.tsx
@@ -5,36 +5,102 @@ import Textarea from "./../../components/ui/TextArea";
 import UploadButton from "../../components/ui/UploadButton";
 import Button from "../../components/ui/Button";
 import { useEffect, useRef, useState } from "react";
+import axios from "axios";
 
 const RoadReportForm = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { location: reportLocation, address } = location.state || {};
-  const [textContent, setTextContent] = useState("");
+  const [content, setContent] = useState("");
   const [uploadedFiles, setUploadedFiles] = useState<File[]>([]);
 
   const [isPhotoUploaded, setIsPhotoUploaded] = useState(false);
-  const isButtonDisabled = !isPhotoUploaded || textContent.trim() === "";
-
-  console.log(address);
+  const isButtonDisabled = content.trim() === "";
+  //!isPhotoUploaded || textContent.trim() === "";
 
   useEffect(() => {
-    console.log(reportLocation);
+    //console.log(reportLocation);
     if (!reportLocation || !address) {
       alert("잘못된 접근입니다.");
       navigate("/road/new/positioning");
     }
   }, [reportLocation, address, navigate]);
 
-  const submitForm = () => {
-    // 불편 도로 제보 API 연동, 성공시 submit 페이지로 이동
-    console.log(reportLocation);
-    console.log(`주소: ${address}`);
-    console.log(uploadedFiles);
-    console.log(`내용: ${textContent}`);
+  const submitForm = async () => {
+    //console.log(reportLocation);
+    //console.log(`주소: ${address}`);
+    //console.log(uploadedFiles);
+    //console.log(`내용: ${content}`);
 
-    navigate("/submit/completed");
+    try {
+      const formData = new FormData();
+      uploadedFiles.forEach((file) => {
+        formData.append("files", file);
+        console.log(file);
+      });
+      formData.append("latitude", reportLocation.lat.toString());
+      formData.append("longitude", reportLocation.lng.toString());
+      formData.append("address", address);
+      formData.append("content", content);
+
+      const response = await axios.post("/api/roadReport/register", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
+
+      navigate("/submit/completed");
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response) {
+          console.error("Error response:", error.response.data);
+          alert(error.response.data.message || "Something went wrong");
+        }
+      } else if (error instanceof Error) {
+        console.error("Error submitting form:", error.message);
+        alert("폼 제출에 실패했습니다. 다시 시도해주세요.");
+      } else {
+        console.error("Unknown error", error);
+        alert("알 수 없는 오류가 발생했습니다. 다시 시도해주세요.");
+      }
+    }
   };
+
+  // const submitForm = async () => {
+  //   console.log(reportLocation);
+  //   console.log(`주소: ${address}`);
+  //   console.log(uploadedFiles);
+  //   console.log(`내용: ${content}`);
+
+  //   try {
+  //     const formData = new FormData();
+  //     // uploadedFiles.forEach((file) => {
+  //     //   formData.append("photos", file);
+  //     //   console.log(file);
+  //     // });
+  //     //formData.append("location", JSON.stringify(reportLocation));
+  //     formData.append("latitude", reportLocation.lat);
+  //     formData.append("longitude", reportLocation.lng);
+  //     formData.append("address", address);
+  //     formData.append("content", content);
+
+  //     const response = await fetch("/api/roadReport/register", {
+  //       method: "POST",
+  //       body: formData,
+  //     });
+
+  //     if (!response.ok) {
+  //       const errorData = await response.json();
+  //       console.error("Error response:", errorData);
+  //       throw new Error(errorData.message || "Something went wrong");
+  //     }
+
+  //     navigate("/submit/completed");
+  //   } catch (error) {
+  //     console.error("Error submitting form :", error);
+  //     alert("폼 제출에 실패했습니다. 다시 시도해주세요.");
+  //   }
+  // };
 
   return (
     <Container hasHeader={true} full={true}>
@@ -69,7 +135,7 @@ const RoadReportForm = () => {
           <Textarea
             placeholder="예시. (어떤 장소)에 (어떤 불편함)이 있어요. (어떤 날짜)에는 불편함이 해소될 것 같아요."
             height="200px"
-            onTextChange={setTextContent}
+            onTextChange={setContent}
           />
         </div>
         <p className="text-[#757575] text-sm">

--- a/src/pages/RoadReport/RoadReportForm.tsx
+++ b/src/pages/RoadReport/RoadReportForm.tsx
@@ -43,7 +43,7 @@ const RoadReportForm = () => {
       formData.append("address", address);
       formData.append("content", content);
 
-      const response = await axios.post("/api/roadReport/register", formData, {
+      const response = await axios.post("/api/roadReport/upload", formData, {
         headers: {
           "Content-Type": "multipart/form-data",
         },

--- a/src/types/RoadReportCallTaxi.ts
+++ b/src/types/RoadReportCallTaxi.ts
@@ -1,0 +1,6 @@
+export interface RoadReportCallTaxi {
+  callTaxiContact: string;
+  callTaxiName: string;
+  homePage?: string;
+  canOnlineReserve: boolean;
+}

--- a/src/types/road.ts
+++ b/src/types/road.ts
@@ -2,4 +2,5 @@ export interface Road {
   id: number;
   latitude: number;
   longitude: number;
+  address: string;
 }

--- a/src/types/roadReportCenter.ts
+++ b/src/types/roadReportCenter.ts
@@ -1,0 +1,5 @@
+export interface RoadReportCenter {
+  id: number;
+  centerName: string;
+  centerContact: string;
+}

--- a/src/types/roadReportDetail.ts
+++ b/src/types/roadReportDetail.ts
@@ -1,0 +1,7 @@
+import { RoadReportImage } from "./roadReportImage";
+
+export interface RoadReportDetail {
+  id: number;
+  reportImageList: RoadReportImage[];
+  content: string;
+}

--- a/src/types/roadReportImage.ts
+++ b/src/types/roadReportImage.ts
@@ -1,0 +1,6 @@
+export interface RoadReportImage {
+  url: string;
+  uploadOrder: number;
+  fileName: string;
+  roadReportId: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "downlevelIteration": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## [240720] 통행불편 관련 모달 조회 api 연동 완료
- 240720 프론트엔드 - 메인 화면에서 "통행불편" 아이콘 클릭 시 지도에 승인된 것을 바탕으로 마커 표시함
- merge 요청자: @

## 1. MR 목적
- [x] 1. Main.tsx 화면에서, 관리자로부터 승인된 [통행불편 제보] 마커들을 전체 조회
- [x] 2. 특정 통행불편 마커를 클릭했을 시, 제보했던 사진 및 상세 정보(내용)을 조회
- [x] 3. 민원을 선택했을 시, 해당 Road 정보를 바탕으로 관할구역의 가장 가까운 민원기관을 연결 
- [x] 4. 민원기관 list 조회 - 하드코딩 한다고 했었는데, 전국 17개 시/도 연결된 기관으로 같이 가져오는 게 좋겠다고 판단.
- [x] 5. 콜택시 - 마커의 지역을 기반으로 가장 가까운 콜택시 정보를 연결. 
  - 한 지역 내에서도 콜택시가 여러 개가 있는 경우가 있다보니, 해당 지역(where)을 조건으로 거리를 검색함(order by 거리 limit 1)

## 2. MR 내용
- 렌더링된 화면 모습은 figma 내용과 동일합니다.